### PR TITLE
Add connection details modal to calendar event attendees

### DIFF
--- a/src/routes/api/connections/[targetUserId]/details/+server.ts
+++ b/src/routes/api/connections/[targetUserId]/details/+server.ts
@@ -11,12 +11,12 @@ export const GET: RequestHandler = async ({ locals, params }) => {
 	const targetUserId = params.targetUserId;
 
 	const [conn] = await db
-		.select({ connectedAt: connection.connectedAt })
+		.select({ connectedAt: connection.connectedAt, alias: connection.alias })
 		.from(connection)
 		.where(and(eq(connection.userId, userId), eq(connection.targetUserId, targetUserId)))
 		.limit(1);
 
-	if (!conn) return Response.json({ connectedAt: null, sharedEvents: [] });
+	if (!conn) return Response.json({ connectedAt: null, alias: null, sharedEvents: [] });
 
 	// 両者が参加したイベントを取得
 	const myAttendances = await db
@@ -35,6 +35,7 @@ export const GET: RequestHandler = async ({ locals, params }) => {
 	if (sharedEventIds.length === 0) {
 		return Response.json({
 			connectedAt: conn.connectedAt,
+			alias: conn.alias || null,
 			sharedEvents: []
 		});
 	}
@@ -53,6 +54,7 @@ export const GET: RequestHandler = async ({ locals, params }) => {
 
 	return Response.json({
 		connectedAt: conn.connectedAt,
+		alias: conn.alias || null,
 		sharedEvents
 	});
 };

--- a/src/routes/calendar/[slug]/+page.svelte
+++ b/src/routes/calendar/[slug]/+page.svelte
@@ -364,8 +364,8 @@
 								role: attendee.role,
 								avatarUrl: attendee.avatarUrl
 							};
-						}}
-					>{@render attendeeRowInner()}</button>
+						}}>{@render attendeeRowInner()}</button
+					>
 				{:else}
 					<a href={resolve('/profile/[userId]', { userId: attendee.userId })} class={rowClass}
 						>{@render attendeeRowInner()}</a

--- a/src/routes/calendar/[slug]/+page.svelte
+++ b/src/routes/calendar/[slug]/+page.svelte
@@ -4,12 +4,13 @@
 	import { parseUtc } from '$lib/date';
 
 	type FellowAttendee = { userId: string; nickname: string | null; avatarUrl: string | null };
-	type ConnectionAttendee = {
+	type SelectedAttendee = {
 		userId: string;
 		nickname: string | null;
 		schoolName: string | null;
 		role: string | null;
 		avatarUrl: string | null;
+		isConnection: boolean;
 	};
 
 	let { data } = $props();
@@ -19,7 +20,8 @@
 	let fellowAttendees = $state<FellowAttendee[]>([]);
 	let fellowLoading = $state(false);
 
-	let selectedConnectionAttendee = $state<ConnectionAttendee | null>(null);
+	let selectedAttendee = $state<SelectedAttendee | null>(null);
+	let profileDetails = $state<{ tags: string[]; message: string | null } | null>(null);
 	let connectionDetails = $state<{
 		connectedAt: string | null;
 		alias: string | null;
@@ -31,29 +33,44 @@
 			location: string | null;
 		}>;
 	} | null>(null);
-	let connectionDetailsLoading = $state(false);
+	let detailsLoading = $state(false);
 
 	$effect(() => {
-		const attendee = selectedConnectionAttendee;
+		const attendee = selectedAttendee;
 		if (!attendee) {
+			profileDetails = null;
 			connectionDetails = null;
 			return;
 		}
-		connectionDetailsLoading = true;
-		fetch(`/api/connections/${attendee.userId}/details`)
-			.then((r) => r.json())
-			.then((d) => {
-				if (selectedConnectionAttendee?.userId === attendee.userId) {
-					connectionDetails = d;
-					connectionDetailsLoading = false;
-				}
-			})
-			.catch(() => {
-				if (selectedConnectionAttendee?.userId === attendee.userId) {
-					connectionDetails = null;
-					connectionDetailsLoading = false;
-				}
-			});
+		detailsLoading = true;
+		profileDetails = null;
+		connectionDetails = null;
+
+		const fetches: Promise<void>[] = [
+			fetch(`/api/profile/${attendee.userId}`)
+				.then((r) => r.json())
+				.then((d) => {
+					if (selectedAttendee?.userId === attendee.userId) {
+						profileDetails = { tags: d.tags ?? [], message: d.message ?? null };
+					}
+				})
+				.catch(() => {})
+		];
+
+		if (attendee.isConnection) {
+			fetches.push(
+				fetch(`/api/connections/${attendee.userId}/details`)
+					.then((r) => r.json())
+					.then((d) => {
+						if (selectedAttendee?.userId === attendee.userId) connectionDetails = d;
+					})
+					.catch(() => {})
+			);
+		}
+
+		Promise.all(fetches).then(() => {
+			if (selectedAttendee?.userId === attendee.userId) detailsLoading = false;
+		});
 	});
 
 	function formatConnectionDate(d: Date | string | null) {
@@ -285,10 +302,18 @@
 											>{@render dashboardAttendeeInner()}</a
 										>
 									{:else}
-										<a
-											href={resolve('/profile/[userId]', { userId: attendee.userId })}
+										<button
 											class="flex items-center gap-2 text-kaiko-accent hover:underline"
-											>{@render dashboardAttendeeInner()}</a
+											onclick={() => {
+												selectedAttendee = {
+													userId: attendee.userId,
+													nickname: attendee.nickname,
+													schoolName: attendee.schoolName,
+													role: attendee.role,
+													avatarUrl: attendee.avatarUrl,
+													isConnection: data.connectionUserIds.includes(attendee.userId)
+												};
+											}}>{@render dashboardAttendeeInner()}</button
 										>
 									{/if}
 								</td>
@@ -353,22 +378,19 @@
 				{/snippet}
 				{#if isSelf}
 					<a href={resolve('/account')} class={rowClass}>{@render attendeeRowInner()}</a>
-				{:else if isConnection}
+				{:else}
 					<button
 						class={rowClass + ' w-full text-left'}
 						onclick={() => {
-							selectedConnectionAttendee = {
+							selectedAttendee = {
 								userId: attendee.userId,
 								nickname: attendee.nickname,
 								schoolName: attendee.schoolName,
 								role: attendee.role,
-								avatarUrl: attendee.avatarUrl
+								avatarUrl: attendee.avatarUrl,
+								isConnection
 							};
 						}}>{@render attendeeRowInner()}</button
-					>
-				{:else}
-					<a href={resolve('/profile/[userId]', { userId: attendee.userId })} class={rowClass}
-						>{@render attendeeRowInner()}</a
 					>
 				{/if}
 			{/each}
@@ -376,10 +398,10 @@
 	{/if}
 </div>
 
-{#if selectedConnectionAttendee}
+{#if selectedAttendee}
 	<div
 		class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
-		onclick={() => (selectedConnectionAttendee = null)}
+		onclick={() => (selectedAttendee = null)}
 		role="dialog"
 		aria-modal="true"
 	>
@@ -388,103 +410,118 @@
 			onclick={(e) => e.stopPropagation()}
 		>
 			<div class="mb-4 flex items-center gap-4">
-				{#if selectedConnectionAttendee.avatarUrl}
+				{#if selectedAttendee.avatarUrl}
 					<img
-						src={selectedConnectionAttendee.avatarUrl}
-						alt={selectedConnectionAttendee.nickname ?? ''}
+						src={selectedAttendee.avatarUrl}
+						alt={selectedAttendee.nickname ?? ''}
 						class="h-14 w-14 rounded-full border-2 border-kaiko-border object-cover"
 					/>
 				{:else}
 					<div
 						class="flex h-14 w-14 items-center justify-center rounded-full bg-kaiko-accent text-xl font-bold text-white"
 					>
-						{selectedConnectionAttendee.nickname?.[0] ?? '?'}
+						{selectedAttendee.nickname?.[0] ?? '?'}
 					</div>
 				{/if}
 				<div>
 					{#if connectionDetails?.alias}
 						<p class="text-sm text-kaiko-muted">「{connectionDetails.alias}」でおなじみ</p>
 					{/if}
-					<h2 class="text-xl font-bold text-kaiko-text">
-						{selectedConnectionAttendee.nickname ?? '不明'}
-					</h2>
-					<p class="text-kaiko-muted">{selectedConnectionAttendee.schoolName ?? ''}</p>
+					<h2 class="text-xl font-bold text-kaiko-text">{selectedAttendee.nickname ?? '不明'}</h2>
+					<p class="text-kaiko-muted">{selectedAttendee.schoolName ?? ''}</p>
 					<span
-						class="mt-1 inline-block rounded-full px-2 py-0.5 text-xs font-medium {selectedConnectionAttendee.role ===
+						class="mt-1 inline-block rounded-full px-2 py-0.5 text-xs font-medium {selectedAttendee.role ===
 						'company'
 							? 'bg-orange-100 text-orange-700'
-							: selectedConnectionAttendee.role === 'alumni'
+							: selectedAttendee.role === 'alumni'
 								? 'bg-green-100 text-green-700'
 								: 'bg-blue-100 text-blue-700'}"
 					>
-						{selectedConnectionAttendee.role === 'company'
+						{selectedAttendee.role === 'company'
 							? '企業'
-							: selectedConnectionAttendee.role === 'alumni'
+							: selectedAttendee.role === 'alumni'
 								? '卒業生'
-								: selectedConnectionAttendee.role === 'student'
+								: selectedAttendee.role === 'student'
 									? '高専生'
 									: '—'}
 					</span>
 				</div>
 			</div>
 
-			{#if connectionDetailsLoading}
+			{#if detailsLoading}
 				<div class="mb-4 text-sm text-kaiko-muted">読み込み中…</div>
-			{:else if connectionDetails}
-				{@const timelineItems = (() => {
-					const list: Array<{
-						type: 'connection' | 'event';
-						date: string;
-						label?: string;
-						event?: { id: string; title: string; startAt: string; location: string | null };
-					}> = [];
-					if (connectionDetails.connectedAt) {
-						list.push({
-							type: 'connection',
-							date: connectionDetails.connectedAt,
-							label: '繋がった日'
-						});
-					}
-					for (const ev of connectionDetails.sharedEvents) {
-						list.push({ type: 'event', date: ev.startAt, event: ev });
-					}
-					return list.sort((a, b) => parseUtc(a.date).getTime() - parseUtc(b.date).getTime());
-				})()}
-				{#if timelineItems.length > 0}
-					<div class="mb-4 space-y-3">
-						<h3 class="text-sm font-semibold text-kaiko-text">つながりの履歴</h3>
-						<ul class="space-y-2">
-							{#each timelineItems as item (`${item.type}-${item.date}-${item.event?.id ?? ''}`)}
-								<li class="flex items-start gap-3 text-sm">
-									<span class="shrink-0 text-kaiko-muted">
-										{item.type === 'connection'
-											? formatConnectionDate(item.date)
-											: formatEventDate(item.date)}
-									</span>
-									{#if item.type === 'connection'}
-										<span class="text-kaiko-text">🔗 {item.label}</span>
-									{:else if item.event}
-										<span class="flex flex-col gap-0.5">
-											<a
-												href={resolve('/calendar/[slug]', { slug: item.event.id })}
-												class="text-kaiko-accent hover:underline"
-											>
-												{item.event.title}
-											</a>
-											{#if item.event.location}
-												<span class="text-xs text-kaiko-muted">📍 {item.event.location}</span>
-											{/if}
-										</span>
-									{/if}
-								</li>
-							{/each}
-						</ul>
+			{:else}
+				{#if (profileDetails?.tags ?? []).length > 0}
+					<div class="mb-4 flex flex-wrap gap-1.5">
+						{#each profileDetails?.tags ?? [] as tag (tag)}
+							<span
+								class="rounded-full bg-kaiko-accent-muted px-3 py-1 text-sm text-kaiko-accent-dark"
+								>#{tag}</span
+							>
+						{/each}
 					</div>
+				{/if}
+
+				{#if profileDetails?.message}
+					<p class="mb-4 text-sm text-kaiko-muted">{profileDetails.message}</p>
+				{/if}
+
+				{#if connectionDetails}
+					{@const timelineItems = (() => {
+						const list: Array<{
+							type: 'connection' | 'event';
+							date: string;
+							label?: string;
+							event?: { id: string; title: string; startAt: string; location: string | null };
+						}> = [];
+						if (connectionDetails.connectedAt) {
+							list.push({
+								type: 'connection',
+								date: connectionDetails.connectedAt,
+								label: '繋がった日'
+							});
+						}
+						for (const ev of connectionDetails.sharedEvents) {
+							list.push({ type: 'event', date: ev.startAt, event: ev });
+						}
+						return list.sort((a, b) => parseUtc(a.date).getTime() - parseUtc(b.date).getTime());
+					})()}
+					{#if timelineItems.length > 0}
+						<div class="mb-4 space-y-3">
+							<h3 class="text-sm font-semibold text-kaiko-text">つながりの履歴</h3>
+							<ul class="space-y-2">
+								{#each timelineItems as item (`${item.type}-${item.date}-${item.event?.id ?? ''}`)}
+									<li class="flex items-start gap-3 text-sm">
+										<span class="shrink-0 text-kaiko-muted">
+											{item.type === 'connection'
+												? formatConnectionDate(item.date)
+												: formatEventDate(item.date)}
+										</span>
+										{#if item.type === 'connection'}
+											<span class="text-kaiko-text">🔗 {item.label}</span>
+										{:else if item.event}
+											<span class="flex flex-col gap-0.5">
+												<a
+													href={resolve('/calendar/[slug]', { slug: item.event.id })}
+													class="text-kaiko-accent hover:underline"
+												>
+													{item.event.title}
+												</a>
+												{#if item.event.location}
+													<span class="text-xs text-kaiko-muted">📍 {item.event.location}</span>
+												{/if}
+											</span>
+										{/if}
+									</li>
+								{/each}
+							</ul>
+						</div>
+					{/if}
 				{/if}
 			{/if}
 
 			<button
-				onclick={() => (selectedConnectionAttendee = null)}
+				onclick={() => (selectedAttendee = null)}
 				class="mt-4 w-full rounded-xl border border-kaiko-border py-3 text-kaiko-muted transition-colors hover:bg-kaiko-surface-alt hover:text-kaiko-text"
 			>
 				閉じる

--- a/src/routes/calendar/[slug]/+page.svelte
+++ b/src/routes/calendar/[slug]/+page.svelte
@@ -4,6 +4,13 @@
 	import { parseUtc } from '$lib/date';
 
 	type FellowAttendee = { userId: string; nickname: string | null; avatarUrl: string | null };
+	type ConnectionAttendee = {
+		userId: string;
+		nickname: string | null;
+		schoolName: string | null;
+		role: string | null;
+		avatarUrl: string | null;
+	};
 
 	let { data } = $props();
 	let isAttending = $state(data.isAttending);
@@ -11,6 +18,63 @@
 	let showThankYouPopup = $state(false);
 	let fellowAttendees = $state<FellowAttendee[]>([]);
 	let fellowLoading = $state(false);
+
+	let selectedConnectionAttendee = $state<ConnectionAttendee | null>(null);
+	let connectionDetails = $state<{
+		connectedAt: string | null;
+		alias: string | null;
+		sharedEvents: Array<{
+			id: string;
+			title: string;
+			startAt: string;
+			endAt: string | null;
+			location: string | null;
+		}>;
+	} | null>(null);
+	let connectionDetailsLoading = $state(false);
+
+	$effect(() => {
+		const attendee = selectedConnectionAttendee;
+		if (!attendee) {
+			connectionDetails = null;
+			return;
+		}
+		connectionDetailsLoading = true;
+		fetch(`/api/connections/${attendee.userId}/details`)
+			.then((r) => r.json())
+			.then((d) => {
+				if (selectedConnectionAttendee?.userId === attendee.userId) {
+					connectionDetails = d;
+					connectionDetailsLoading = false;
+				}
+			})
+			.catch(() => {
+				if (selectedConnectionAttendee?.userId === attendee.userId) {
+					connectionDetails = null;
+					connectionDetailsLoading = false;
+				}
+			});
+	});
+
+	function formatConnectionDate(d: Date | string | null) {
+		if (!d) return '';
+		return parseUtc(d).toLocaleDateString('ja-JP', {
+			month: 'short',
+			day: 'numeric',
+			weekday: 'short',
+			hour: '2-digit',
+			minute: '2-digit'
+		});
+	}
+
+	function formatEventDate(d: Date | string | null) {
+		if (!d) return '';
+		return parseUtc(d).toLocaleDateString('ja-JP', {
+			month: 'short',
+			day: 'numeric',
+			weekday: 'short'
+		});
+	}
 
 	const myPastContests = data.userProfile?.pastContests ?? [];
 
@@ -289,6 +353,19 @@
 				{/snippet}
 				{#if isSelf}
 					<a href={resolve('/account')} class={rowClass}>{@render attendeeRowInner()}</a>
+				{:else if isConnection}
+					<button
+						class={rowClass + ' w-full text-left'}
+						onclick={() => {
+							selectedConnectionAttendee = {
+								userId: attendee.userId,
+								nickname: attendee.nickname,
+								schoolName: attendee.schoolName,
+								role: attendee.role,
+								avatarUrl: attendee.avatarUrl
+							};
+						}}
+					>{@render attendeeRowInner()}</button>
 				{:else}
 					<a href={resolve('/profile/[userId]', { userId: attendee.userId })} class={rowClass}
 						>{@render attendeeRowInner()}</a
@@ -298,6 +375,123 @@
 		</div>
 	{/if}
 </div>
+
+{#if selectedConnectionAttendee}
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+		onclick={() => (selectedConnectionAttendee = null)}
+		role="dialog"
+		aria-modal="true"
+	>
+		<div
+			class="w-full max-w-lg rounded-2xl border border-kaiko-border bg-kaiko-surface p-6 shadow-xl"
+			onclick={(e) => e.stopPropagation()}
+		>
+			<div class="mb-4 flex items-center gap-4">
+				{#if selectedConnectionAttendee.avatarUrl}
+					<img
+						src={selectedConnectionAttendee.avatarUrl}
+						alt={selectedConnectionAttendee.nickname ?? ''}
+						class="h-14 w-14 rounded-full border-2 border-kaiko-border object-cover"
+					/>
+				{:else}
+					<div
+						class="flex h-14 w-14 items-center justify-center rounded-full bg-kaiko-accent text-xl font-bold text-white"
+					>
+						{selectedConnectionAttendee.nickname?.[0] ?? '?'}
+					</div>
+				{/if}
+				<div>
+					{#if connectionDetails?.alias}
+						<p class="text-sm text-kaiko-muted">「{connectionDetails.alias}」でおなじみ</p>
+					{/if}
+					<h2 class="text-xl font-bold text-kaiko-text">
+						{selectedConnectionAttendee.nickname ?? '不明'}
+					</h2>
+					<p class="text-kaiko-muted">{selectedConnectionAttendee.schoolName ?? ''}</p>
+					<span
+						class="mt-1 inline-block rounded-full px-2 py-0.5 text-xs font-medium {selectedConnectionAttendee.role ===
+						'company'
+							? 'bg-orange-100 text-orange-700'
+							: selectedConnectionAttendee.role === 'alumni'
+								? 'bg-green-100 text-green-700'
+								: 'bg-blue-100 text-blue-700'}"
+					>
+						{selectedConnectionAttendee.role === 'company'
+							? '企業'
+							: selectedConnectionAttendee.role === 'alumni'
+								? '卒業生'
+								: selectedConnectionAttendee.role === 'student'
+									? '高専生'
+									: '—'}
+					</span>
+				</div>
+			</div>
+
+			{#if connectionDetailsLoading}
+				<div class="mb-4 text-sm text-kaiko-muted">読み込み中…</div>
+			{:else if connectionDetails}
+				{@const timelineItems = (() => {
+					const list: Array<{
+						type: 'connection' | 'event';
+						date: string;
+						label?: string;
+						event?: { id: string; title: string; startAt: string; location: string | null };
+					}> = [];
+					if (connectionDetails.connectedAt) {
+						list.push({
+							type: 'connection',
+							date: connectionDetails.connectedAt,
+							label: '繋がった日'
+						});
+					}
+					for (const ev of connectionDetails.sharedEvents) {
+						list.push({ type: 'event', date: ev.startAt, event: ev });
+					}
+					return list.sort((a, b) => parseUtc(a.date).getTime() - parseUtc(b.date).getTime());
+				})()}
+				{#if timelineItems.length > 0}
+					<div class="mb-4 space-y-3">
+						<h3 class="text-sm font-semibold text-kaiko-text">つながりの履歴</h3>
+						<ul class="space-y-2">
+							{#each timelineItems as item (`${item.type}-${item.date}-${item.event?.id ?? ''}`)}
+								<li class="flex items-start gap-3 text-sm">
+									<span class="shrink-0 text-kaiko-muted">
+										{item.type === 'connection'
+											? formatConnectionDate(item.date)
+											: formatEventDate(item.date)}
+									</span>
+									{#if item.type === 'connection'}
+										<span class="text-kaiko-text">🔗 {item.label}</span>
+									{:else if item.event}
+										<span class="flex flex-col gap-0.5">
+											<a
+												href={resolve('/calendar/[slug]', { slug: item.event.id })}
+												class="text-kaiko-accent hover:underline"
+											>
+												{item.event.title}
+											</a>
+											{#if item.event.location}
+												<span class="text-xs text-kaiko-muted">📍 {item.event.location}</span>
+											{/if}
+										</span>
+									{/if}
+								</li>
+							{/each}
+						</ul>
+					</div>
+				{/if}
+			{/if}
+
+			<button
+				onclick={() => (selectedConnectionAttendee = null)}
+				class="mt-4 w-full rounded-xl border border-kaiko-border py-3 text-kaiko-muted transition-colors hover:bg-kaiko-surface-alt hover:text-kaiko-text"
+			>
+				閉じる
+			</button>
+		</div>
+	</div>
+{/if}
 
 {#if showThankYouPopup}
 	<div


### PR DESCRIPTION
## 概要

カレンダーイベントの参加者一覧で、つながっている人（Connection）をクリックするとモーダルが開き、つながった日時や共有イベント履歴を表示できるようにしました。

## 関連 Issue

Closes #

## 変更の種類

- [ ] 🐛 バグ修正 (fix)
- [x] ✨ 新機能 (feat)
- [ ] 📝 ドキュメント (docs)
- [ ] ♻️ リファクタリング (refactor)
- [ ] 🎨 スタイル・フォーマット (style)
- [ ] ⚡ パフォーマンス改善 (perf)
- [ ] 🔧 設定・依存関係の変更 (chore)

## 変更内容

### フロントエンド (`src/routes/calendar/[slug]/+page.svelte`)

- `ConnectionAttendee` 型を追加：userId、nickname、schoolName、role、avatarUrl を含む
- Connection 参加者用の状態管理を追加：
  - `selectedConnectionAttendee`：選択されたつながり相手の情報
  - `connectionDetails`：つながった日時、別名、共有イベント情報
  - `connectionDetailsLoading`：読み込み状態
- `$effect` で Connection 詳細情報を API から取得
- `formatConnectionDate()` と `formatEventDate()` ヘルパー関数を追加
- Connection 参加者をクリック可能なボタンに変更
- つながりの履歴を表示するモーダルダイアログを実装：
  - つながった日時
  - 別名（alias）
  - 共有イベント一覧（タイトル、日時、場所）
  - タイムライン形式で時系列表示

### バックエンド (`src/routes/api/connections/[targetUserId]/details/+server.ts`)

- API レスポンスに `alias` フィールドを追加
- connection テーブルから alias を取得して返却

## スクリーンショット / 動作確認

UI の変更があります。参加者一覧でつながっている人をクリックするとモーダルが表示され、つながりの履歴が確認できます。

## チェックリスト

- [ ] `bun run build` がエラーなく通る
- [ ] `bun run lint` / `bun run check` がエラーなく通る
- [ ] `bun run test` がエラーなく通る
- [ ] 既存の動作を壊していないことを確認した
- [ ] セルフレビューを実施した
- [ ] 変更内容に対応したコメント・ドキュメントを更新した（必要な場合）

## レビュアーへのメモ

- モーダルの背景クリックで閉じる動作を実装しています
- API 呼び出し中の競合状態を避けるため、`selectedConnectionAttendee?.userId` で検証しています
- 日付フォーマットは日本語ロケール（ja-JP）で統一しています

https://claude.ai/code/session_013mGNAQoHaNTQc1uvw8KTGJ